### PR TITLE
Build: Add production target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 
 all: country.sys
 
+production: country.sys
+	$(CP) country.sys ..$(DIRSEP)bin
+
 country.sys: country.asm
-	nasm -o $@ $<
+	nasm -o $@ country.asm
 
 clean:
 	$(RM) country.sys
+
+clobber: clean


### PR DESCRIPTION
So that a superior make or script can call us to install.