### PR TITLE
CI: Update upload

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,8 +35,8 @@ jobs:
         ./ci_validate.py
 
     - name: Upload binary artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
-        name: country.sys
+        name: country
         path: country.sys
         retention-days: 30


### PR DESCRIPTION
1/ Update the action use due to node 20 deprecation
2/ Upload is a zip file, so avoid double extension .sys.zip